### PR TITLE
Add logic that allows webhook removal 

### DIFF
--- a/lib/particle/client/webhooks.rb
+++ b/lib/particle/client/webhooks.rb
@@ -56,7 +56,11 @@ module Particle
       # @return [boolean] true for success
       def remove_webhook(target)
         result = delete(webhook(target).path)
-        result[:ok]
+        if result.blank?
+          true
+        else
+          result[:ok]
+        end
       end
     end
   end


### PR DESCRIPTION
When I was triggering a webhook removal, either by `Particle.remove_webhook` or `.remove`, I was getting the error:

```
2.3.3 :003 > w.remove
TypeError: no implicit conversion of Symbol into Integer
	from /Users/brianhedberg/Projects/particlerb/lib/particle/client/webhooks.rb:59:in `[]'
	from /Users/brianhedberg/Projects/particlerb/lib/particle/client/webhooks.rb:59:in `remove_webhook'
	from /Users/brianhedberg/Projects/particlerb/lib/particle/webhook.rb:46:in `remove'
	from (irb):3
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/railties-5.0.6/lib/rails/commands/console.rb:65:in `start'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/railties-5.0.6/lib/rails/commands/console_helper.rb:9:in `start'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/railties-5.0.6/lib/rails/commands/commands_tasks.rb:78:in `console'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/railties-5.0.6/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/railties-5.0.6/lib/rails/commands.rb:18:in `<top (required)>'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:293:in `require'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:293:in `block in require'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:259:in `load_dependency'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:293:in `require'
	from /Users/brianhedberg/Projects/sprowt/app-rails/bin/rails:9:in `<top (required)>'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:287:in `load'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:287:in `block in load'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:259:in `load_dependency'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/activesupport-5.0.6/lib/active_support/dependencies.rb:287:in `load'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/commands/rails.rb:6:in `call'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/command_wrapper.rb:38:in `call'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/application.rb:201:in `block in serve'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/application.rb:171:in `fork'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/application.rb:171:in `serve'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/application.rb:141:in `block in run'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/application.rb:135:in `loop'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/application.rb:135:in `run'
	from /Users/brianhedberg/.rvm/gems/ruby-2.3.3@sprowt-rails-devise-pundit/gems/spring-2.0.2/lib/spring/application/boot.rb:19:in `<top (required)>'
	from /Users/brianhedberg/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Users/brianhedberg/.rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
```

This is a bandaid fix that allows a webhook to be removed without raising an error. Ideally it would only be raised if the removal wasn't allowed, but not enough time to do that right now. 