### PR TITLE
Create product endpoints

### DIFF
--- a/lib/particle.rb
+++ b/lib/particle.rb
@@ -30,14 +30,12 @@ module Particle
       token
     end
 
-    def login_product(username, password, options = {})
+    def login_as_product(username, password, options = {})
       options[:is_product?] = true
       options[:grant_type] = 'client_credentials'
       options[:client] = options[:client_id]
       options[:secret] = options[:client_secret]
       token = client.login(username, password, options)
-      puts "Token"
-      puts token.inspect
       self.access_token = token.access_token || token.token
       token
     end

--- a/lib/particle.rb
+++ b/lib/particle.rb
@@ -30,6 +30,18 @@ module Particle
       token
     end
 
+    def login_product(username, password, options = {})
+      options[:is_product?] = true
+      options[:grant_type] = 'client_credentials'
+      options[:client] = options[:client_id]
+      options[:secret] = options[:client_secret]
+      token = client.login(username, password, options)
+      puts "Token"
+      puts token.inspect
+      self.access_token = token.access_token || token.token
+      token
+    end
+
     private
 
     def respond_to_missing?(method_name, include_private = false)

--- a/lib/particle/client.rb
+++ b/lib/particle/client.rb
@@ -51,9 +51,32 @@ module Particle
     # @param value [String] 40 character Particle OAuth2 access token
     def access_token=(value)
       reset_connection
-      @access_token = 
+      @access_token =
         if value.respond_to? :access_token
           value.access_token
+        else
+          value
+        end
+    end
+
+    # Set OAuth2 access token for authentication
+    #
+    # @param value [String] 40 character Particle OAuth2 access token
+    def client_id=(value)
+      reset_connection
+      @client_id =
+        if value.respond_to? :client_id
+          value.client_id
+        else
+          value
+        end
+    end
+
+    def client_secret=(value)
+      reset_connection
+      @client_secret =
+        if value.respond_to? :client_secret
+          value.client_secret
         else
           value
         end

--- a/lib/particle/client/devices.rb
+++ b/lib/particle/client/devices.rb
@@ -24,7 +24,10 @@ module Particle
       #
       # @return [Array<Device>] List of Particle devices to interact with
       def devices
-        get(Device.list_path).map do |attributes|
+        devices = get(Device.list_path)
+        devices = devices[:devices] unless !devices.is_a? Hash
+
+        devices.map do |attributes|
           device(attributes)
         end
       end

--- a/lib/particle/client/devices.rb
+++ b/lib/particle/client/devices.rb
@@ -50,6 +50,16 @@ module Particle
         device(result[:id])
       end
 
+      # Create a claim code for customer to claim their device via Two-Legged Auth
+      #
+      # @param target [String, Device] A device id or {Device} object.
+      #                                You can't claim a device by name
+      # @return [Device] A device object to interact with
+      def create_claim_code(target)
+        result = post(Device.claim_code_path, id: device(target).id_or_name)
+        device(result[:id])
+      end
+
       # Create a new Particle device
       #
       # @param product [String] A product id

--- a/lib/particle/client/tokens.rb
+++ b/lib/particle/client/tokens.rb
@@ -70,10 +70,7 @@ module Particle
           username: client,
           password: secret
         }
-        puts data
-        puts 'yo from particlerb----------------------------------'
-        puts http_options
-        puts Token.create_path
+
         result = request(:post, Token.create_path, data, http_options)
         result[:token] = result.delete(:access_token)
         token(result)

--- a/lib/particle/client/tokens.rb
+++ b/lib/particle/client/tokens.rb
@@ -76,24 +76,6 @@ module Particle
         token(result)
       end
 
-      # def create_product_token(username, password, options = {})
-      #   client = options.delete(:client) { 'particle' }
-      #   secret = options.delete(:secret) { 'particle' }
-      #   data = URI.encode_www_form({
-      #     grant_type: 'client_credentials',
-      #     username: username,
-      #     password: password
-      #   }.merge(options))
-      #   http_options = {
-      #     headers: { content_type: "application/x-www-form-urlencoded" },
-      #     username: client,
-      #     password: secret
-      #   }
-      #   result = request(:post, Token.create_path, data, http_options)
-      #   result[:token] = result.delete(:access_token)
-      #   token(result)
-      # end
-
       # Authenticate with Particle and start using the token on the
       # client right away
       #
@@ -105,11 +87,7 @@ module Particle
       #                       create the token.
       # @return [Token] The token object
       def login(username, password, options = {})
-        # if options[:is_product?]
-          # token = create_product_token(client_id, client_secret, options)
-        # else
-          token = create_token(username, password, options)
-        # end
+        token = create_token(username, password, options)
         self.access_token = token
         token
       end

--- a/lib/particle/client/tokens.rb
+++ b/lib/particle/client/tokens.rb
@@ -59,8 +59,9 @@ module Particle
       def create_token(username, password, options = {})
         client = options.delete(:client) { 'particle' }
         secret = options.delete(:secret) { 'particle' }
+        grant_type = options[:grant_type] || 'password'
         data = URI.encode_www_form({
-          grant_type: 'password',
+          grant_type: grant_type,
           username: username,
           password: password
         }.merge(options))
@@ -69,10 +70,32 @@ module Particle
           username: client,
           password: secret
         }
+        puts data
+        puts 'yo from particlerb----------------------------------'
+        puts http_options
+        puts Token.create_path
         result = request(:post, Token.create_path, data, http_options)
         result[:token] = result.delete(:access_token)
         token(result)
       end
+
+      # def create_product_token(username, password, options = {})
+      #   client = options.delete(:client) { 'particle' }
+      #   secret = options.delete(:secret) { 'particle' }
+      #   data = URI.encode_www_form({
+      #     grant_type: 'client_credentials',
+      #     username: username,
+      #     password: password
+      #   }.merge(options))
+      #   http_options = {
+      #     headers: { content_type: "application/x-www-form-urlencoded" },
+      #     username: client,
+      #     password: secret
+      #   }
+      #   result = request(:post, Token.create_path, data, http_options)
+      #   result[:token] = result.delete(:access_token)
+      #   token(result)
+      # end
 
       # Authenticate with Particle and start using the token on the
       # client right away
@@ -85,7 +108,11 @@ module Particle
       #                       create the token.
       # @return [Token] The token object
       def login(username, password, options = {})
-        token = create_token(username, password, options)
+        # if options[:is_product?]
+          # token = create_product_token(client_id, client_secret, options)
+        # else
+          token = create_token(username, password, options)
+        # end
         self.access_token = token
         token
       end

--- a/lib/particle/client/webhooks.rb
+++ b/lib/particle/client/webhooks.rb
@@ -56,7 +56,7 @@ module Particle
       # @return [boolean] true for success
       def remove_webhook(target)
         result = delete(webhook(target).path)
-        if result.blank?
+        unless result.is_a? Hash
           true
         else
           result[:ok]

--- a/lib/particle/configurable.rb
+++ b/lib/particle/configurable.rb
@@ -15,7 +15,7 @@ module Particle
     #   @return [String] Configure User-Agent header for requests.
 
     attr_accessor :access_token, :connection_options,
-      :user_agent
+      :user_agent, :client_id, :client_secret, :product_id
     attr_writer :api_endpoint
 
     class << self
@@ -24,7 +24,9 @@ module Particle
           :access_token,
           :api_endpoint,
           :connection_options,
-          :user_agent
+          :user_agent,
+          :client_id,
+          :client_secret
         ]
       end
     end

--- a/lib/particle/default.rb
+++ b/lib/particle/default.rb
@@ -1,8 +1,6 @@
 require 'particle/version'
-require 'pry'
 
 module Particle
-
   # Default configuration options for {Client}
   module Default
     API_ENDPOINT = "https://api.particle.io".freeze

--- a/lib/particle/default.rb
+++ b/lib/particle/default.rb
@@ -1,4 +1,5 @@
 require 'particle/version'
+require 'pry'
 
 module Particle
 
@@ -22,6 +23,15 @@ module Particle
 
       def access_token
         ENV['PARTICLE_ACCESS_TOKEN']
+      end
+
+      def client_id
+      end
+
+      def client_secret
+      end
+
+      def product_id
       end
 
       # Default options for Faraday::Connection

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -1,5 +1,5 @@
 require 'particle/model'
-
+require 'pry'
 module Particle
 
   # Domain model for one Particle device
@@ -142,7 +142,7 @@ module Particle
     # @return [OpenStruct] Result of flashing.
     #                :ok => true on success
     #                :errors => String with compile errors
-    #                
+    #
     def flash(file_paths, options = {})
       @client.flash_device(self, file_paths, options)
     end
@@ -154,7 +154,7 @@ module Particle
     # @return [OpenStruct] Result of flashing.
     #                :ok => true on success
     #                :errors => String with compile errors
-    #                
+    #
     def compile(file_paths)
       @client.compile(file_paths, device_id: id)
     end
@@ -171,15 +171,15 @@ module Particle
     end
 
     def self.list_path
-      "v1/devices"
+      "v1/products/#{Particle.product_id}/devices"
     end
 
     def self.claim_path
-      "v1/devices"
+      "v1/products/#{Particle.product_id}/devices"
     end
 
     def self.provision_path
-      "v1/devices"
+      "v1/products/#{Particle.product_id}/devices"
     end
 
     def update_keys_path
@@ -187,8 +187,28 @@ module Particle
     end
 
     def path
-      "/v1/devices/#{id_or_name}"
+      "/v1/products/#{Particle.product_id}/devices/#{id_or_name}"
     end
+
+    # def self.list_path
+    #   "v1/devices"
+    # end
+
+    # def self.claim_path
+    #   "v1/devices"
+    # end
+
+    # def self.provision_path
+    #   "v1/devices"
+    # end
+
+    # def update_keys_path
+    #   "/v1/provisioning/#{id}"
+    # end
+
+    # def path
+    #   "/v1/devices/#{id_or_name}"
+    # end
 
     def function_path(name)
       path + "/#{name}"

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -1,7 +1,6 @@
 require 'particle/model'
-require 'pry'
-module Particle
 
+module Particle
   # Domain model for one Particle device
   class Device < Model
     ID_REGEX = /^\h{24}$/

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -171,7 +171,7 @@ module Particle
     end
 
     def self.list_path
-      unless Particle.product_id.blank?
+      if Particle.product_id
         "v1/products/#{Particle.product_id}/devices"
       else
         "v1/devices"
@@ -179,7 +179,7 @@ module Particle
     end
 
     def self.claim_path
-      unless Particle.product_id.blank?
+      if Particle.product_id
         "v1/products/#{Particle.product_id}/devices"
       else
         "v1/devices"
@@ -187,7 +187,7 @@ module Particle
     end
 
     def self.provision_path
-      unless Particle.product_id.blank?
+      if Particle.product_id
         "v1/products/#{Particle.product_id}/devices"
       else
         "v1/devices"
@@ -203,7 +203,7 @@ module Particle
     end
 
     def path
-      unless Particle.product_id.blank?
+      if Particle.product_id
         "/v1/products/#{Particle.product_id}/devices/#{id_or_name}"
       else
         "/v1/devices/#{id_or_name}"

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -171,15 +171,27 @@ module Particle
     end
 
     def self.list_path
-      "v1/products/#{Particle.product_id}/devices"
+      unless Particle.product_id.blank?
+        "v1/products/#{Particle.product_id}/devices"
+      else
+        "v1/devices"
+      end
     end
 
     def self.claim_path
-      "v1/products/#{Particle.product_id}/devices"
+      unless Particle.product_id.blank?
+        "v1/products/#{Particle.product_id}/devices"
+      else
+        "v1/devices"
+      end
     end
 
     def self.provision_path
-      "v1/products/#{Particle.product_id}/devices"
+      unless Particle.product_id.blank?
+        "v1/products/#{Particle.product_id}/devices"
+      else
+        "v1/devices"
+      end
     end
 
     def self.claim_code_path
@@ -191,28 +203,12 @@ module Particle
     end
 
     def path
-      "/v1/products/#{Particle.product_id}/devices/#{id_or_name}"
+      unless Particle.product_id.blank?
+        "/v1/products/#{Particle.product_id}/devices/#{id_or_name}"
+      else
+        "/v1/devices/#{id_or_name}"
+      end
     end
-
-    # def self.list_path
-    #   "v1/devices"
-    # end
-
-    # def self.claim_path
-    #   "v1/devices"
-    # end
-
-    # def self.provision_path
-    #   "v1/devices"
-    # end
-
-    # def update_keys_path
-    #   "/v1/provisioning/#{id}"
-    # end
-
-    # def path
-    #   "/v1/devices/#{id_or_name}"
-    # end
 
     def function_path(name)
       path + "/#{name}"

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -182,6 +182,10 @@ module Particle
       "v1/products/#{Particle.product_id}/devices"
     end
 
+    def self.claim_code_path
+      "v1/products/#{Particle.product_id}/device_claims"
+    end
+
     def update_keys_path
       "/v1/provisioning/#{id}"
     end

--- a/lib/particle/webhook.rb
+++ b/lib/particle/webhook.rb
@@ -46,28 +46,28 @@ module Particle
       @client.remove_webhook(self)
     end
 
-    # def self.list_path
-    #   "v1/webhooks"
-    # end
-
-    # def self.create_path
-    #   "v1/webhooks"
-    # end
-
-    # def path
-    #   "/v1/webhooks/#{id}"
-    # end
-
     def self.list_path
-      "v1/products/#{Particle.product_id}/integrations"
+      unless Particle.product_id.blank?
+        "v1/products/#{Particle.product_id}/integrations"
+      else
+        "v1/webhooks"
+      end
     end
 
     def self.create_path
-      "v1/products/#{Particle.product_id}/integrations"
+      unless Particle.product_id.blank?
+        "v1/products/#{Particle.product_id}/integrations"
+      else
+        "v1/webhooks"
+      end
     end
 
     def path
-      "/v1/products/#{Particle.product_id}/integrations/#{id}"
+      unless Particle.product_id.blank?
+        "/v1/products/#{Particle.product_id}/integrations/#{id}"
+      else
+        "/v1/webhooks/#{id}"
+      end
     end
   end
 end

--- a/lib/particle/webhook.rb
+++ b/lib/particle/webhook.rb
@@ -47,7 +47,7 @@ module Particle
     end
 
     def self.list_path
-      unless Particle.product_id.blank?
+      if Particle.product_id
         "v1/products/#{Particle.product_id}/integrations"
       else
         "v1/webhooks"
@@ -55,7 +55,7 @@ module Particle
     end
 
     def self.create_path
-      unless Particle.product_id.blank?
+      if Particle.product_id
         "v1/products/#{Particle.product_id}/integrations"
       else
         "v1/webhooks"
@@ -63,7 +63,7 @@ module Particle
     end
 
     def path
-      unless Particle.product_id.blank?
+      if Particle.product_id
         "/v1/products/#{Particle.product_id}/integrations/#{id}"
       else
         "/v1/webhooks/#{id}"

--- a/lib/particle/webhook.rb
+++ b/lib/particle/webhook.rb
@@ -46,16 +46,28 @@ module Particle
       @client.remove_webhook(self)
     end
 
+    # def self.list_path
+    #   "v1/webhooks"
+    # end
+
+    # def self.create_path
+    #   "v1/webhooks"
+    # end
+
+    # def path
+    #   "/v1/webhooks/#{id}"
+    # end
+
     def self.list_path
-      "v1/webhooks"
+      "v1/products/#{Particle.product_id}/integrations"
     end
 
     def self.create_path
-      "v1/webhooks"
+      "v1/products/#{Particle.product_id}/integrations"
     end
 
     def path
-      "/v1/webhooks/#{id}"
+      "/v1/products/#{Particle.product_id}/integrations/#{id}"
     end
   end
 end


### PR DESCRIPTION
The `particlerb` gem doesn't allow an application to programmatically log in as a product owner.

This changeset allows for product auth and adds product endpoints. Ideally, the product endpoints wouldn't be replacing the non-product enpoints, but given our time contraints on this project, this seems like a more realistic path.