### PR TITLE
Owner enabled

### DIFF
--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -37,9 +37,14 @@ module Particle
       @attributes[:id] || @attributes[:name]
     end
 
+    def owner
+      get_attributes unless @attributes[:owner]
+      @attributes[:owner]
+    end
+
     attribute_reader :connected, :product_id, :last_heard, :last_app,
       :last_ip_address, :platform_id, :cellular, :status, :iccid,
-      :imei, :current_build_target, :default_build_target, :system_firmware_version
+      :imei, :current_build_target, :default_build_target, :system_firmware_version, :owner
 
     alias_method :connected?, :connected
     alias_method :cellular?, :cellular

--- a/lib/particle/device.rb
+++ b/lib/particle/device.rb
@@ -42,9 +42,15 @@ module Particle
       @attributes[:owner]
     end
 
+    def customer_id
+      get_attributes unless @attributes[:customer_id]
+      @attributes[:customer_id]
+    end
+
     attribute_reader :connected, :product_id, :last_heard, :last_app,
       :last_ip_address, :platform_id, :cellular, :status, :iccid,
-      :imei, :current_build_target, :default_build_target, :system_firmware_version, :owner
+      :imei, :current_build_target, :default_build_target, :system_firmware_version,
+      :owner, :customer_id
 
     alias_method :connected?, :connected
     alias_method :cellular?, :cellular


### PR DESCRIPTION
These changes allow someone to access the `owner` and `customer_id` for a specific device.

For example:

```rb
Particle.devices.each { |device| puts device.owner }
``` 

This was put in place because the following wasn't always working.

```rb
Particle.product('1234').find_customer_by_device('asdfasdfasdfasdfasdf').username